### PR TITLE
Drop loop argument from async function calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     zip_safe=True,
     packages=find_packages("src"),
     package_dir={"": "src"},
-    python_requires=">=3.6.*",
+    python_requires=">=3.8",
     install_requires=[
         "aio-udp-server==0.0.6",
         "Cerberus==1.3.1",

--- a/src/aiokrpc/server.py
+++ b/src/aiokrpc/server.py
@@ -83,13 +83,13 @@ class KRPCServer:
 
     # region Query implementation
     async def _catch_response(self, key):
-        queue = asyncio.Queue(loop=self.loop)
+        queue = asyncio.Queue()
 
         self.requests[key] = queue
         try:
             for attempt in range(3):
                 try:
-                    rt, response = await asyncio.wait_for(queue.get(), 10, loop=self.loop)
+                    rt, response = await asyncio.wait_for(queue.get(), 10)
                     if rt == "e":
                         raise KRPCErrorResponse(response)
                     else:
@@ -106,7 +106,7 @@ class KRPCServer:
 
         self.server.send(msg, addr)
 
-        return asyncio.ensure_future(self._catch_response(self._make_query_key(addr, t)), loop=self.loop)
+        return asyncio.ensure_future(self._catch_response(self._make_query_key(addr, t)))
 
     # endregion
 


### PR DESCRIPTION
Deprecated since version 3.8, was removed in version 3.10.

Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>